### PR TITLE
Reporte inicial + fix clientes/proveedores

### DIFF
--- a/clientes/forms.py
+++ b/clientes/forms.py
@@ -22,11 +22,14 @@ class ClienteForm(ModelForm):
         )
 
     def clean_cuit(self):
-        """ Validar no existe un cliente soft-deleted con el mismo CUIT"""
+        """ Validar no existe un cliente soft-deleted con el mismo CUIT (Excepto CUITs vacíos)"""
 
         cuit = self.cleaned_data.get("cuit")
-
         modelo = self.Meta.model
+
+        # Excepción para registros soft-deleted con CUIT vacío
+        if cuit is None:
+            return cuit
 
         # Validación sólo para casos de soft-delete
         # Si existe y no fue borrado se muestra la validación por defecto de Django

--- a/clientes/models.py
+++ b/clientes/models.py
@@ -35,7 +35,7 @@ class Cliente(BaseModel):
         return f"{self.nombre} {self.apellido}"
 
     def save(self, *args, **kwargs):
-        """ Si el CUIT existe entre los borrados no se puede crear el cliente."""
+        """ Si el CUIT existe entre los borrados no se puede crear el cliente. (Excepto CUITs vacíos)"""
 
         if self.cuit:
             qs = Cliente.all_objects.filter(cuit=self.cuit)

--- a/clientes/templates/clientes/cliente_update_form.html
+++ b/clientes/templates/clientes/cliente_update_form.html
@@ -17,31 +17,40 @@
                 <legend class="border-bottom mb-3">Actualizar Cliente</legend>
                 <div class="">
                     <div class="form-row">
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.nombre|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.apellido|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
-                            {{ form.email|as_crispy_field }}
+                        <div class="form-group col-md-3">
+                            {{ form.cuit|as_crispy_field }}
                         </div>
                     </div>
                     <div class="form-row">
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
+                            {{ form.email|as_crispy_field }}
+                        </div>
+                        <div class="form-group col-md-3">
                             {{ form.telefono|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-2">
                             {{ form.calle|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-2">
                             {{ form.numero|as_crispy_field }}
                         </div>
-                    </div>
-
-                    <div class="form-group">
-                        <div class="col-md-4 px-0">
-                            {{ form.localidad|as_crispy_field }}
+                        <div class="form-group col-md-3">
+                            <div>
+                                {{ form.localidad|as_crispy_field }}
+                            </div>
+                            <div>
+                                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+                                    Agregar localidad
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/clientes/tests/test_models.py
+++ b/clientes/tests/test_models.py
@@ -68,3 +68,26 @@ def test_Cliente_se_puede_restaurar():
     client.save()
 
     assert Cliente.objects.count() == 1
+
+
+@pytest.mark.django_db()
+def test_cliente_soft_deleted_CUIT():
+    """ Crear cliente con CUIT == None habiendo otro cliente soft-deleted también con CUIT None """
+
+    cliente = ClienteFactory(nombre="Cliente", apellido="1")
+
+    assert Cliente.all_objects.count() == 1
+
+    cliente.delete()
+
+    # El manager `objects` devuelve sólo las instancias activas
+    assert Cliente.objects.count() == 0
+    # El manager `all_objects` devuelve todas las instancias creadas
+    assert Cliente.all_objects.count() == 1
+
+    # Nuevo cliente con mismo cuit (Unique key) da error de integridad
+    cliente = ClienteFactory(nombre="Cliente", apellido="2")
+
+    # Existen 2 clientes con cuit None, 1 activo / 1 S-D
+    assert Cliente.objects.count() == 1
+    assert Cliente.all_objects.count() == 2

--- a/clientes/urls.py
+++ b/clientes/urls.py
@@ -5,6 +5,7 @@ from .views import (
     ClienteCreateView,
     ClienteUpdateView,
     ClienteDeleteView,
+    reporte_clientes,
 )
 
 app_name = "clientes"
@@ -14,4 +15,5 @@ urlpatterns = [
     path("<int:pk>/", ClienteDetailView.as_view(), name="detail"),
     path("<int:pk>/delete/", ClienteDeleteView.as_view(), name="delete"),
     path("<int:pk>/update/", ClienteUpdateView.as_view(), name="update"),
+    path("reportes/", reporte_clientes, name="reporte"),
 ]

--- a/core/templates/core/reporte.html
+++ b/core/templates/core/reporte.html
@@ -1,0 +1,66 @@
+<div id="container" style="width: 75%;">
+    <canvas id="clientes-chart" data-url="{% url 'clientes:reporte' %}"></canvas>
+  </div>
+
+  <script>
+
+        function dynamicColors() {
+            var r = Math.floor(Math.random() * 255);
+            var g = Math.floor(Math.random() * 255);
+            var b = Math.floor(Math.random() * 255);
+            return "rgba(" + r + "," + g + "," + b + ", 0.5)";
+        }
+        
+        function poolColors(a) {
+            var pool = [];
+            for(i = 0; i < a; i++) {
+                pool.push(dynamicColors());
+            }
+            return pool;
+        }
+
+    $(function () {
+
+        // https://www.chartjs.org/docs/latest/general/fonts.html
+        Chart.defaults.global.defaultFontSize = 16;
+
+        let $clientesChart = $('#clientes-chart')
+
+        $.ajax({
+            url: $clientesChart.data("url"),
+            success: function (data) {
+                var ctx = $clientesChart[0].getContext("2d");
+
+                new Chart(ctx, {
+                    type: 'pie',
+                    data: {
+                        labels: data.labels,
+                        datasets: [{
+                            data: data.num_clientes,
+                            label: 'Numero de clientes',
+                            // backgroundColor: ["#0074D9", "#FF4136", "#2ECC40", "#FF851B", "#7FDBFF", "#B10DC9", "#FFDC00", "#001f3f", "#39CCCC", "#01FF70", "#85144b", "#F012BE", "#3D9970", "#111111", "#AAAAAA"],
+                            backgroundColor: poolColors(data.num_clientes.length),
+                            borderColor: "#0",
+                            borderWidth: 1,
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        legend: {
+                            position: 'top',
+                        },
+                        title: {
+                            display: true,
+                            text: 'Clientes por localidad'
+                        }
+                    }
+                });
+              }
+          })
+      })
+  </script>
+
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"></script>
+{% endblock extra_js %}

--- a/pedidos/forms.py
+++ b/pedidos/forms.py
@@ -76,7 +76,7 @@ class ProductosPedidoForm(forms.ModelForm):
         self.helper.field_class = "col-auto"
         self.helper.layout = Layout(
             Row(
-                Field("producto"),
+                Field("producto", css_class="w-auto"),
                 Field("cantidad"),
                 Field("DELETE"),
                 css_class=f"formset_row-{formtag_prefix}",

--- a/proveedores/forms.py
+++ b/proveedores/forms.py
@@ -21,11 +21,14 @@ class ProveedorForm(ModelForm):
         )
 
     def clean_cuit(self):
-        """ Validar no existe un proveedor soft-deleted con el mismo CUIT"""
+        """ Validar no existe un proveedor soft-deleted con el mismo CUIT. (Excepto CUITs vacíos)"""
 
         cuit = self.cleaned_data.get("cuit")
-
         modelo = self.Meta.model
+
+        # Excepción para registros soft-deleted con CUIT vacío
+        if cuit is None:
+            return cuit
 
         # Validación sólo para casos de soft-delete
         # Si existe y no fue borrado se muestra la validación por defecto de Django

--- a/proveedores/models.py
+++ b/proveedores/models.py
@@ -38,7 +38,7 @@ class Proveedor(BaseModel):
         return reverse("proveedores:detail", kwargs={"pk": self.pk})
 
     def save(self, *args, **kwargs):
-        """ Si el CUIT existe entre los borrados no se puede crear el proveedor."""
+        """ Si el CUIT existe entre los borrados no se puede crear el proveedor. (Excepto CUITs vacíos)"""
 
         if self.cuit:
             qs = Proveedor.all_objects.filter(cuit=self.cuit)

--- a/proveedores/templates/proveedores/proveedor_form.html
+++ b/proveedores/templates/proveedores/proveedor_form.html
@@ -44,7 +44,7 @@
                     </div>
 
                     <div class="form-group">
-                        <div class="col-md-3 px-0">
+                        <div class="col-md-4 px-0">
                             {{ form.localidad|as_crispy_field }}
                         </div>
                         <div>

--- a/proveedores/templates/proveedores/proveedor_update_form.html
+++ b/proveedores/templates/proveedores/proveedor_update_form.html
@@ -16,24 +16,24 @@
                 <legend class="border-bottom mb-3">Actualizar Proveedor</legend>
                 <div>
                     <div class="form-row">
-                        <div class="form-group col-md-4">
-                            {{ form.cuit|as_crispy_field }}
-                        </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.razon_social|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
+                            {{ form.cuit|as_crispy_field }}
+                        </div>
+                        <div class="form-group col-md-3">
                             {{ form.email|as_crispy_field }}
                         </div>
                     </div>
                     <div class="form-row">
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.telefono|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.calle|as_crispy_field }}
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-3">
                             {{ form.numero|as_crispy_field }}
                         </div>
                     </div>
@@ -41,6 +41,11 @@
                     <div class="form-group">
                         <div class="col-md-4 px-0">
                             {{ form.localidad|as_crispy_field }}
+                        </div>
+                        <div>
+                            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+                                Agregar localidad
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/proveedores/tests/test_models.py
+++ b/proveedores/tests/test_models.py
@@ -40,3 +40,26 @@ def test_proveedor_se_puede_restaurar():
     prov.save()
 
     assert Proveedor.objects.count() == 1
+
+
+@pytest.mark.django_db()
+def test_proveedor_soft_deleted_CUIT():
+    """ Crear proveedor con CUIT == None habiendo otro proveedor soft-deleted también con CUIT None """
+
+    proveedor = ProveedorFactory(razon_social="Prueba 1")
+
+    assert Proveedor.all_objects.count() == 1
+
+    proveedor.delete()
+
+    # El manager `objects` devuelve sólo las instancias activas
+    assert Proveedor.objects.count() == 0
+    # El manager `all_objects` devuelve todas las instancias creadas
+    assert Proveedor.all_objects.count() == 1
+
+    # Nuevo proveedor con mismo cuit (Unique key) da error de integridad
+    proveedor = ProveedorFactory(razon_social="Prueba 2")
+
+    # Existen 2 proveedores con cuit None, 1 activo / 1 S-D
+    assert Proveedor.objects.count() == 1
+    assert Proveedor.all_objects.count() == 2

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,8 @@
 <div class="content-section">
     <h2 class="border-bottom mb-3">Inicio</h2>
     
-</div>
+    {% include 'core/reporte.html' %}
+</div>  
 
 <!-- Inicio End -->
 

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -131,7 +131,7 @@
 		</li>
 		<hr class="sidebar-divider my-0" />
 		<li class="nav-item">
-			<a class="nav-link" href="#">
+			<a class="nav-link {% active 'reportes/' %}" href="{% url 'clientes:reporte' %}">
 				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
 					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 					<path d="M3 3v18h18" />


### PR DESCRIPTION
- Reporte inicial con chart.js
- Agregué campo CUIT en form de cliente/proveedor
- Ahora se puede cargar un cliente/proveedor con CUIT vacío aunque exista otro soft-deleted
- Tests para esto último